### PR TITLE
Fix "How to run" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Playground project to learn more about the Mach-O file format.
 
 ## How to run
 
-`swift run MachO-Reader <path-to-binary>`
+`swift run macho-reader <path-to-binary>`
 
 You should see a similar output:
 ![image](./images/example.png)


### PR DESCRIPTION
The "How to run" section in the readme file states that the tool can be used by executing `swift run MachO-Reader <path-to-binary>` command. However, the `Package.swift` definition only includes an executable named `macho-reader`. Therefore, the correct command to run the tool should be:

`swift run macho-reader <path-to-binary>`


Example:
```
dpalo@DPALO-M-XPCF MachO-Reader % swift run MachO-Reader
error: no executable product named 'MachO-Reader'
dpalo@DPALO-M-XPCF MachO-Reader % swift run macho-reader
Building for debugging...
Build complete! (0.16s)
```