### PR TITLE
feat: Implement symbol report

### DIFF
--- a/Sources/MachOReaderCLI/Commands/MachOReaderCommand.swift
+++ b/Sources/MachOReaderCLI/Commands/MachOReaderCommand.swift
@@ -5,6 +5,10 @@ struct MachOReaderCommand: ParsableCommand {
 
     static let configuration = CommandConfiguration(commandName: "macho-reader",
                                                     abstract: "Parse and inspect Mach-O binaries.",
-                                                    subcommands: [InfoCommand.self, DyldChainedFixupsCommand.self],
+                                                    subcommands: [
+                                                        InfoCommand.self,
+                                                        DyldChainedFixupsCommand.self,
+                                                        SymbolsCommand.self,
+                                                    ],
                                                     defaultSubcommand: InfoCommand.self)
 }

--- a/Sources/MachOReaderCLI/Commands/SymbolsCommand.swift
+++ b/Sources/MachOReaderCLI/Commands/SymbolsCommand.swift
@@ -54,6 +54,7 @@ struct SymbolsCommand: ParsableCommand {
     private func printText(symbols: [Symbol]) {
         let formatter = TextFormatter()
 
+        print("SYMBOLS (\(symbols.count)):")
         for (idx, symbol) in symbols.enumerated() {
             print("[\(idx)]".padding(6) + formatter.format(symbol))
         }

--- a/Sources/MachOReaderCLI/Commands/SymbolsCommand.swift
+++ b/Sources/MachOReaderCLI/Commands/SymbolsCommand.swift
@@ -1,0 +1,74 @@
+import ArgumentParser
+import Foundation
+import MachOReaderLib
+
+struct SymbolsCommand: ParsableCommand {
+
+    static let configuration = CommandConfiguration(commandName: "symbols",
+                                                    abstract: "List the symbol table (LC_SYMTAB) entries.")
+
+    // MARK: - Properties
+
+    @Option(help: "The arch of the mach-o header to read.")
+    var arch: String?
+
+    @Flag(help: "Only outputs undefined symbols (N_UNDF).")
+    var undefined: Bool = false
+
+    @Flag(help: "Only outputs external symbols (N_EXT).")
+    var external: Bool = false
+
+    @Option(name: .long, help: "Output format: text or json")
+    var format: OutputFormat = .text
+
+    @Argument(help: "The binary to inspect.")
+    var pathToBinary: String
+
+    // MARK: - Methods
+
+    func run() throws {
+        let expandedPath = (pathToBinary as NSString).expandingTildeInPath
+        let url = URL(fileURLWithPath: expandedPath)
+
+        let file = try MachOFile(from: url, arch: arch)
+        let report = try file.symbolTableReport()
+
+        let symbols = filtered(report.symbols)
+
+        switch format {
+        case .text:
+            printText(symbols: symbols)
+        case .json:
+            printJSON(symbols: symbols)
+        }
+    }
+
+    private func filtered(_ symbols: [Symbol]) -> [Symbol] {
+        symbols.filter { symbol in
+            (!undefined || symbol.type == .undefined) && (!external || symbol.isExternal)
+        }
+    }
+
+    // MARK: - Text Output
+
+    private func printText(symbols: [Symbol]) {
+        let formatter = TextFormatter()
+
+        for (idx, symbol) in symbols.enumerated() {
+            print("[\(idx)]".padding(6) + formatter.format(symbol))
+        }
+    }
+
+    // MARK: - JSON Output
+
+    private func printJSON(symbols: [Symbol]) {
+        let formatter = JSONFormatter()
+
+        let symbolsArray = symbols.enumerated().map { idx, symbol -> [String: Any] in
+            var result = formatter.format(symbol)
+            result["index"] = idx
+            return result
+        }
+        print(formatter.toJSONString(symbolsArray))
+    }
+}

--- a/Sources/MachOReaderCLI/Formatting/JSONFormatter.swift
+++ b/Sources/MachOReaderCLI/Formatting/JSONFormatter.swift
@@ -345,6 +345,37 @@ final class JSONFormatter {
         return result
     }
 
+    // MARK: - Symbol Table
+
+    func format(_ report: SymbolTableReport) -> [String: Any] {
+        [
+            "symbols": report.symbols.enumerated().map { idx, symbol in
+                var result = format(symbol)
+                result["index"] = idx
+                return result
+            },
+        ]
+    }
+
+    func format(_ symbol: Symbol) -> [String: Any] {
+        var result: [String: Any] = [
+            "string_table_index": symbol.stringTableIndex,
+            "type": symbol.type.readableValue ?? String(symbol.type.rawValue),
+            "is_external": symbol.isExternal,
+            "is_private_external": symbol.isPrivateExternal,
+            "is_stab": symbol.isStab,
+            "section": symbol.sectionNumber,
+            "value": symbol.value,
+            "value_hex": String(hex: symbol.value),
+        ]
+
+        if let name = symbol.name {
+            result["name"] = name
+        }
+
+        return result
+    }
+
     // MARK: - Dyld Chained Fixups
 
     func format(_ report: DyldChainedFixupsReport) -> [String: Any] {

--- a/Sources/MachOReaderCLI/Formatting/TextFormatter.swift
+++ b/Sources/MachOReaderCLI/Formatting/TextFormatter.swift
@@ -353,6 +353,28 @@ final class TextFormatter {
         ].joined()
     }
 
+    // MARK: - Symbol Table
+
+    func format(_ report: SymbolTableReport) -> String {
+        var output = "SYMBOLS (\(report.symbols.count)):"
+        for (idx, symbol) in report.symbols.enumerated() {
+            output += "\n" + "[\(idx)]".padding(6) + format(symbol)
+        }
+        return output
+    }
+
+    func format(_ symbol: Symbol) -> String {
+        [
+            "value: \(String(hex: symbol.value))",
+            config.fieldSeparator,
+            "type: \(symbol.readableType.padding(20))",
+            config.fieldSeparator,
+            "sect: \(String(symbol.sectionNumber).padding(4))",
+            config.fieldSeparator,
+            symbol.name ?? "<no name>",
+        ].joined()
+    }
+
     // MARK: - Dyld Chained Fixups
 
     func format(_ report: DyldChainedFixupsReport) -> String {

--- a/Sources/MachOReaderLib/Extensions/Array+Extensions.swift
+++ b/Sources/MachOReaderLib/Extensions/Array+Extensions.swift
@@ -12,6 +12,16 @@ extension [LoadCommand] {
             .first
     }
 
+    func getSymtabCommand() -> SymtabCommand? {
+        lazy
+            .filter { loadCommand in loadCommand.cmd == .symtab }
+            .compactMap { loadCommand -> SymtabCommand? in
+                guard case let .symtabCommand(symtabCommand) = loadCommand.commandType() else { return nil }
+                return symtabCommand
+            }
+            .first
+    }
+
     func getDylibCommands() -> [DylibCommand] {
         compactMap { loadCommand -> DylibCommand? in
             guard case let .dylibCommand(dylibCommand) = loadCommand.commandType() else { return nil }

--- a/Sources/MachOReaderLib/MachOReader.swift
+++ b/Sources/MachOReaderLib/MachOReader.swift
@@ -48,6 +48,10 @@ public final class MachOReader {
             }
     }
 
+    public func getSymbolTableReport() throws -> SymbolTableReport {
+        try file.symbolTableReport()
+    }
+
     // TODO: Add tests to this
     public func getLoadCommands(_ cmd: String) -> [LoadCommand] {
         file.commands.filter { (loadCommand: LoadCommand) in

--- a/Sources/MachOReaderLib/Models/MachOFile.swift
+++ b/Sources/MachOReaderLib/Models/MachOFile.swift
@@ -10,12 +10,17 @@ public enum MachOFileError: Error, Equatable, CustomStringConvertible {
     /// The file does not contain an `LC_DYLD_CHAINED_FIXUPS` load command.
     case missingDyldChainedFixups
 
+    /// The file does not contain an `LC_SYMTAB` load command.
+    case missingSymbolTable
+
     public var description: String {
         switch self {
         case let .invalidMagic(value):
             "Invalid Mach-O magic: 0x\(String(value, radix: 16)). The file is not a valid Mach-O binary."
         case .missingDyldChainedFixups:
             "This Mach-O binary does not contain an LC_DYLD_CHAINED_FIXUPS load command."
+        case .missingSymbolTable:
+            "This Mach-O binary does not contain an LC_SYMTAB load command."
         }
     }
 }
@@ -72,5 +77,9 @@ public struct MachOFile {
 
     public func dyldChainedFixupsReport() throws -> DyldChainedFixupsReport {
         try DyldChainedFixupsReport(file: self)
+    }
+
+    public func symbolTableReport() throws -> SymbolTableReport {
+        try SymbolTableReport(file: self)
     }
 }

--- a/Sources/MachOReaderLib/Reports/SymbolTableReport/Symbol.swift
+++ b/Sources/MachOReaderLib/Reports/SymbolTableReport/Symbol.swift
@@ -1,0 +1,108 @@
+import Foundation
+import MachO
+
+/// A single entry of the Mach-O symbol table (an `nlist_64`), with its name
+/// resolved from the string table.
+///
+/// Only the 64-bit `nlist_64` layout is supported — the library is
+/// 64-bit-focused and there is no 32-bit `nlist` path.
+public struct Symbol {
+
+    // MARK: - Properties
+
+    /// Byte index into the string table (`n_strx`). `0` means "no name".
+    public let stringTableIndex: UInt32
+    /// The symbol type, decoded from `n_type & N_TYPE`.
+    public let type: SymbolType
+    /// The section number (`n_sect`); `NO_SECT` (0) when not in a section.
+    public let sectionNumber: UInt8
+    /// The `n_desc` field (named `desc`, not `description`, to avoid colliding
+    /// with `CustomStringConvertible`).
+    public let desc: UInt16
+    /// The symbol's value (`n_value`) — typically an address for defined symbols.
+    public let value: UInt64
+
+    /// The symbol name, resolved from the string table during the build.
+    public internal(set) var name: String?
+
+    /// The raw `n_type` byte, kept for the mask-bit flags below.
+    private let rawType: UInt8
+
+    // MARK: - Lifecycle
+
+    init(_ nlist: nlist_64) {
+        stringTableIndex = nlist.n_un.n_strx
+        rawType = nlist.n_type
+        type = SymbolType(nlist.n_type & UInt8(N_TYPE))
+        sectionNumber = nlist.n_sect
+        desc = nlist.n_desc
+        value = nlist.n_value
+    }
+
+    // MARK: - Flags (n_type mask bits)
+
+    /// Whether the symbol is a debugging (STAB) symbol (`N_STAB`).
+    public var isStab: Bool {
+        rawType & UInt8(N_STAB) != 0
+    }
+
+    /// Whether the symbol is a private external symbol (`N_PEXT`).
+    public var isPrivateExternal: Bool {
+        rawType & UInt8(N_PEXT) != 0
+    }
+
+    /// Whether the symbol is external (`N_EXT`).
+    public var isExternal: Bool {
+        rawType & UInt8(N_EXT) != 0
+    }
+
+    // MARK: - Readable
+
+    /// A human-readable description of the set flags and the symbol type,
+    /// e.g. `"N_EXT | N_SECT"`.
+    public var readableType: String {
+        var parts: [String] = []
+        if isStab { parts.append("N_STAB") }
+        if isPrivateExternal { parts.append("N_PEXT") }
+        if isExternal { parts.append("N_EXT") }
+        parts.append(type.readableValue ?? String(type.rawValue))
+        return parts.joined(separator: " | ")
+    }
+}
+
+// MARK: - SymbolType
+
+public extension Symbol {
+
+    /// The masked symbol type (`n_type & N_TYPE`).
+    struct SymbolType: RawRepresentable, Equatable, Readable, Sendable {
+
+        public let rawValue: UInt8
+
+        public init(rawValue: UInt8) {
+            self.rawValue = rawValue
+        }
+
+        init(_ rawValue: UInt8) {
+            self.rawValue = rawValue
+        }
+
+        // Source: <mach-o/nlist.h>
+        public static let undefined = SymbolType(UInt8(N_UNDF))
+        public static let absolute = SymbolType(UInt8(N_ABS))
+        public static let section = SymbolType(UInt8(N_SECT))
+        public static let prebound = SymbolType(UInt8(N_PBUD))
+        public static let indirect = SymbolType(UInt8(N_INDR))
+
+        public var readableValue: String? {
+            switch self {
+            case .undefined: "N_UNDF"
+            case .absolute: "N_ABS"
+            case .section: "N_SECT"
+            case .prebound: "N_PBUD"
+            case .indirect: "N_INDR"
+            default: nil
+            }
+        }
+    }
+}

--- a/Sources/MachOReaderLib/Reports/SymbolTableReport/Symbol.swift
+++ b/Sources/MachOReaderLib/Reports/SymbolTableReport/Symbol.swift
@@ -61,8 +61,11 @@ public struct Symbol {
     /// A human-readable description of the set flags and the symbol type,
     /// e.g. `"N_EXT | N_SECT"`.
     public var readableType: String {
+        // STAB (debug) entries repurpose the whole n_type byte as a stab code,
+        // so the N_TYPE mask and the N_EXT / N_PEXT bits are not meaningful here.
+        if isStab { return "N_STAB" }
+
         var parts: [String] = []
-        if isStab { parts.append("N_STAB") }
         if isPrivateExternal { parts.append("N_PEXT") }
         if isExternal { parts.append("N_EXT") }
         parts.append(type.readableValue ?? String(type.rawValue))

--- a/Sources/MachOReaderLib/Reports/SymbolTableReport/SymbolTableReport.swift
+++ b/Sources/MachOReaderLib/Reports/SymbolTableReport/SymbolTableReport.swift
@@ -1,0 +1,62 @@
+import Foundation
+import MachO
+
+/// Decodes the Mach-O symbol table (`LC_SYMTAB`) into `Symbol`s, resolving each
+/// name from the string table — an `nm`-style view of the binary.
+public final class SymbolTableReport {
+
+    // MARK: - Properties
+
+    let file: MachOFile
+
+    public let symtab: SymtabCommand
+    public private(set) var symbols: [Symbol] = []
+
+    // MARK: - Lifecycle
+
+    init(file: MachOFile) throws {
+        guard let symtab = file.commands.getSymtabCommand() else {
+            throw MachOFileError.missingSymbolTable
+        }
+        self.file = file
+        self.symtab = symtab
+
+        symbols = try SymbolTableBuilder(file: file, symtab: symtab).symbols
+    }
+}
+
+// MARK: - SymbolTableBuilder
+
+/// Walks the `nsyms` fixed-size `nlist_64` entries at `symoff` and resolves each
+/// name from the null-terminated string blob at `stroff`.
+struct SymbolTableBuilder {
+
+    let symbols: [Symbol]
+
+    init(file: MachOFile, symtab: SymtabCommand) throws {
+        // `file.base` is the start of the (slice's) mach_header, so symoff/stroff
+        // — which are relative to it — can be used as direct offsets.
+        let decoder = BinaryDecoder(data: file.base)
+
+        let symoff = Int(symtab.symoff)
+        let stroff = Int(symtab.stroff)
+        let stride = MemoryLayout<nlist_64>.size
+
+        var symbols: [Symbol] = []
+        symbols.reserveCapacity(Int(symtab.nsyms))
+
+        for index in 0 ..< Int(symtab.nsyms) {
+            let nlist = try decoder.decode(nlist_64.self, at: symoff + index * stride)
+            var symbol = Symbol(nlist)
+
+            // n_strx == 0 is the convention for "no name".
+            if symbol.stringTableIndex != 0 {
+                symbol.name = try? decoder.decodeString(at: stroff + Int(symbol.stringTableIndex))
+            }
+
+            symbols.append(symbol)
+        }
+
+        self.symbols = symbols
+    }
+}

--- a/Tests/MachOReaderLibTests/SymbolTableReportTests.swift
+++ b/Tests/MachOReaderLibTests/SymbolTableReportTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+@testable import MachOReaderLib
+import XCTest
+
+/// Ground truth for the `helloworld` fixture, captured via `nm -m` / `otool -l`.
+/// (Mirrors the otool dump convention atop MachOFileTests.swift.)
+///
+/// LC_SYMTAB     nsyms: 31    symoff: 33496   stroff: 34048   strsize: 1112
+/// LC_DYSYMTAB   nlocalsym: 13   nextdefsym: 2   nundefsym: 16   (13 + 2 + 16 == 31)
+///
+/// Defined external (N_SECT | N_EXT) — exactly 2:
+///   0x100000000  T  __mh_execute_header
+///   0x100003db0  T  _main
+/// Undefined external (N_UNDF | N_EXT) — 16, e.g.:
+///   U  _swift_bridgeObjectRetain   (from libswiftCore)
+/// Local (N_SECT / not external) — 13, e.g.:
+///   0x100003e80  t  _$ss27_finalizeUninitializedArrayySayxGABnlF
+final class SymbolTableReportTests: XCTestCase {
+
+    // MARK: - Properties
+
+    var report: SymbolTableReport!
+
+    // MARK: - Set up
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        // Fail loudly if the fixture is missing rather than silently skipping.
+        let url = try XCTUnwrap(url(for: "helloworld"))
+        report = try SymbolTableReport(file: MachOFile(from: url, arch: nil))
+    }
+
+    // MARK: - Tests
+
+    func test_symbolCount_whenHelloworldFixture() {
+        XCTAssertEqual(report.symbols.count, 31)
+    }
+
+    func test_undefinedExternalCount_matchesDysymtab() {
+        let undefinedExternal = report.symbols.filter { $0.type == .undefined && $0.isExternal }
+        XCTAssertEqual(undefinedExternal.count, 16, "Should match LC_DYSYMTAB.nundefsym")
+    }
+
+    func test_definedExternalCount_matchesDysymtab() {
+        let definedExternal = report.symbols.filter { $0.type == .section && $0.isExternal }
+        XCTAssertEqual(definedExternal.count, 2, "Should match LC_DYSYMTAB.nextdefsym")
+
+        let names = Set(definedExternal.compactMap(\.name))
+        XCTAssertEqual(names, ["_main", "__mh_execute_header"])
+    }
+
+    func test_localCount_matchesDysymtab() {
+        let local = report.symbols.filter { !$0.isExternal && !$0.isStab }
+        XCTAssertEqual(local.count, 13, "Should match LC_DYSYMTAB.nlocalsym")
+    }
+
+    func test_resolvesNameAndValue_forMain() throws {
+        let main = try XCTUnwrap(report.symbols.first { $0.name == "_main" })
+        XCTAssertEqual(main.type, .section)
+        XCTAssertTrue(main.isExternal)
+        XCTAssertEqual(main.value, 0x1_0000_3DB0)
+    }
+
+    func test_resolvesName_forUndefinedImport() throws {
+        let symbol = try XCTUnwrap(report.symbols.first { $0.name == "_swift_bridgeObjectRetain" })
+        XCTAssertEqual(symbol.type, .undefined)
+        XCTAssertTrue(symbol.isExternal)
+        XCTAssertEqual(symbol.value, 0)
+    }
+
+    func test_readableType_forMain_containsExtAndSect() throws {
+        let main = try XCTUnwrap(report.symbols.first { $0.name == "_main" })
+        XCTAssertTrue(main.readableType.contains("N_EXT"))
+        XCTAssertTrue(main.readableType.contains("N_SECT"))
+    }
+}

--- a/Tests/MachOReaderLibTests/SymbolTableReportTests.swift
+++ b/Tests/MachOReaderLibTests/SymbolTableReportTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MachO
 @testable import MachOReaderLib
 import XCTest
 
@@ -73,5 +74,17 @@ final class SymbolTableReportTests: XCTestCase {
         let main = try XCTUnwrap(report.symbols.first { $0.name == "_main" })
         XCTAssertTrue(main.readableType.contains("N_EXT"))
         XCTAssertTrue(main.readableType.contains("N_SECT"))
+    }
+
+    func test_readableType_forStabSymbol_reportsOnlyNStab() {
+        // STAB (debug) entries repurpose n_type as a stab code, so the masked
+        // N_TYPE / N_EXT / N_PEXT bits are not meaningful — report N_STAB only.
+        var nlist = nlist_64()
+        nlist.n_type = UInt8(N_OSO) // a real stab code (0x66); its high bits set N_STAB
+
+        let symbol = Symbol(nlist)
+
+        XCTAssertTrue(symbol.isStab)
+        XCTAssertEqual(symbol.readableType, "N_STAB")
     }
 }


### PR DESCRIPTION
- Decodes the nsyms fixed-size nlist_64 records at symoff, and resolves each name from the null-terminated string blob at stroff, using the safe BinaryDecoder (no new uses of the deprecated extract path).
- New Symbol model surfaces value, sectionNumber, the SymbolType kind (N_UNDF/N_ABS/N_SECT/N_PBUD/N_INDR), flags (isExternal/isPrivateExternal/isStab), and a readable type summary. STAB (debug) entries report just N_STAB, since their n_type byte is a stab code rather than the usual flags.
- New symbols CLI subcommand with --undefined / --external filters and --format text|json.
- Scope: nlist_64 only (the library is 64-bit-focused).

<img width="1202" height="790" alt="Screenshot 2026-05-31 at 19 46 12" src="https://github.com/user-attachments/assets/0d11f23f-c172-42f3-8310-fd7e685cdfa4" />
